### PR TITLE
improve the example of `flake.nix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,19 @@ Or, clone the AUR git repo locally (containing the `PKGBUILD` and such), and run
   boot.loader.grub = {
     minegrub-world-sel = {
       enable = true;
-      customIcons = [{
-        name = "nixos";
-        lineTop = "NixOS (23/11/2023, 23:03)";
-        lineBottom = "Survival Mode, No Cheats, Version: 23.11";
-        # Icon: you can use an icon from the remote repo, or load from a local file
-        imgName = "nixos";
-        # customImg = builtins.path {
-        #   path = ./nixos-logo.png;
-        #   name = "nixos-img";
-        # };
-      }];
+      customIcons = with config.system; [
+        {
+          inherit name;
+          lineTop = with nixos; distroName + " " + codeName + " (" + version + ")";
+          lineBottom = "Survival Mode, No Cheats, Version: " + nixos.release;
+          # Icon: you can use an icon from the remote repo, or load from a local file
+          imgName = "nixos";
+          # customImg = builtins.path {
+          #   path = ./nixos-logo.png;
+          #   name = "nixos-img";
+          # };
+        }
+      ];
     };
   };
 


### PR DESCRIPTION
to read fields from the current build:
```sh
ls -1c /nix/store/*-minegrub-world-sel-theme/grub/theme/icons/nixos.png | head -n1 | xargs gwenview
```
<img width="801" height="96" alt="nixos" src="https://github.com/user-attachments/assets/765d3c66-7263-4781-9d09-365f000fefb0" />
