### PR TITLE
fixed typo in installation fix

### DIFF
--- a/install_theme.sh
+++ b/install_theme.sh
@@ -20,7 +20,7 @@ else
 	echo "Can't find a /boot/grub or /boot/grub2 folder. Exiting."
 	exit 
 fi
-theme_path="$grub_path/themes/minegrub-world-select"
+theme_path="$grub_path/themes/minegrub-world-selection"
 
 
 ## Prompts


### PR DESCRIPTION
There is a typo in installation script line 23

should be `theme_path="$grub_path/themes/minegrub-world-selection"`

otherwise the printed entries for /etc/default/grub were wrong