### PR TITLE
Add missing dependency 'which' to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
             name = "minegrub-world-sel-theme";
             src = "${self}";
 
-            buildInputs = [ pkgs.jq pkgs.imagemagick ];
+            buildInputs = [ pkgs.jq pkgs.imagemagick pkgs.which ];
 
             installPhase = ''
               mkdir -p $out/grub/theme/


### PR DESCRIPTION
The recent fix to the ImageMagick detection logic (e702337) revealed that `which` was missing from the derivation's inputs. Previously, the faulty check masked this omission, allowing the build to pass.

Since the new logic correctly relies on `which`, this PR adds it to the inputs to allow the derivation to build.