### PR TITLE
NixOS flake feature: Add `background` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Or, clone the AUR git repo locally (containing the `PKGBUILD` and such), and run
   boot.loader.grub = {
     minegrub-world-sel = {
       enable = true;
+      background = "assets/background-scaled/background-2560x1440.png"; # Path to background image (relative to theme source)
       customIcons = with config.system; [
         {
           inherit name;

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,15 @@
 
               done
 
+              BG_IMG_SRC="../assets/background-scaled/${cfg.backgroundImage}"
+              if [ -f "$BG_IMG_SRC" ]; then
+                echo "Using background image: ${cfg.backgroundImage}"
+                cp -f "$BG_IMG_SRC" "../minegrub-world-selection/background.png"
+              else
+                echo "ERROR: backgroundImage '${cfg.backgroundImage}' not found in assets/background-scaled/" >&2
+                exit 1
+              fi
+
               cp -r ../minegrub-world-selection/* $out/grub/theme/
             '';
           };
@@ -93,6 +102,15 @@
                   For icon file choose only one source:
                   - imgName: Name of the icon to load from the minegrub repository. (from icon-generator folder)
                   - customImg: Path to a custom image file stored locally.
+                '';
+              };
+              backgroundImage = mkOption {
+                type = types.str;
+                default = "background-1920x1080.png";
+                example = "background-2560x1600.png";
+                description = ''
+                  Path to a specific scaled background (any file on assets/background-scaled).
+                  If not set, the theme's default scaled background will be used.
                 '';
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -60,12 +60,12 @@
 
               done
 
-              BG_IMG_SRC="../assets/background-scaled/${cfg.backgroundImage}"
+              BG_IMG_SRC="${self}/${cfg.background}"
               if [ -f "$BG_IMG_SRC" ]; then
-                echo "Using background image: ${cfg.backgroundImage}"
+                echo "Using background image: $BG_IMG_SRC"
                 cp -f "$BG_IMG_SRC" "../minegrub-world-selection/background.png"
               else
-                echo "ERROR: backgroundImage '${cfg.backgroundImage}' not found in assets/background-scaled/" >&2
+                echo "ERROR: $BG_IMG_SRC does not exist" >&2
                 exit 1
               fi
 
@@ -104,14 +104,11 @@
                   - customImg: Path to a custom image file stored locally.
                 '';
               };
-              backgroundImage = mkOption {
+              background = mkOption {
                 type = types.str;
-                default = "background-1920x1080.png";
-                example = "background-2560x1600.png";
-                description = ''
-                  Path to a specific scaled background (any file on assets/background-scaled).
-                  If not set, the theme's default scaled background will be used.
-                '';
+                default = "assets/background-scaled/background-1920x1080.png";
+                example = "assets/background-scaled/background-2560x1440.png";
+                description = "Path to background image, relative to the theme source";
               };
             };
           };


### PR DESCRIPTION
## What
Adds a `background` option to the NixOS module, letting users select
which image (from the theme's source) gets used as background,
instead of always relying on the one already committed in
`minegrub-world-selection/background.png`.

## Why
Currently, changing the background via the flake requires manually
overwriting `minegrub-world-selection/background.png` in a fork/checkout.
This exposes a first-class NixOS option to select it more easily.

## Usage
```nix
boot.loader.grub.minegrub-world-sel = {
  enable = true;
  background = "assets/background-scaled/background-2560x1600.png";
  # defaults to "assets/background-scaled/background-1920x1080.png"
};
```

## Testing
Built the theme derivation directly (via a throwaway NixOS module test)
with both the default and a custom `background`, and confirmed
`background.png` in the output matches the selected source file.
Also confirmed the build fails loudly should an invalid filename be set, so it doesn't break grub.